### PR TITLE
Make logs to be appended, not overwritten

### DIFF
--- a/template
+++ b/template
@@ -33,7 +33,7 @@ case "$1" in
     else
         echo "Starting $name"
         cd "$dir"
-        sudo -u "$user" $cmd > "$stdout_log" 2> "$stderr_log" &
+        sudo -u "$user" $cmd >> "$stdout_log" 2>> "$stderr_log" &
         echo $! > "$pid_file"
         if ! is_running; then
             echo "Unable to start, see $stdout_log and $stderr_log"


### PR DESCRIPTION
Daemon logs is the only available debugging source. So why not to collect them if we can?
Anyway, it is a logrotate job to keep logs compact.
