### PR TITLE
fixed incorrect status with blank pid file

### DIFF
--- a/template
+++ b/template
@@ -23,7 +23,7 @@ get_pid() {
 }
 
 is_running() {
-    [ -f "$pid_file" ] && ps `get_pid` > /dev/null 2>&1
+    [ -f "$pid_file" ] && ps -p `get_pid` > /dev/null 2>&1
 }
 
 case "$1" in


### PR DESCRIPTION
Thanks for this template, it saved me from writing lots of boilerplate. This just addresses a minor bug I encountered. If cmd fails to execute, an empty pid file is created, and status simply executes "ps", which of course succeeds. The -p ensures that it will fail if no PID is present.
