### PR TITLE
check for file with content

### DIFF
--- a/template
+++ b/template
@@ -23,7 +23,7 @@ get_pid() {
 }
 
 is_running() {
-    [ -f "$pid_file" ] && ps `get_pid` > /dev/null 2>&1
+    [ -s "$pid_file" ] && ps `get_pid` > /dev/null 2>&1
 }
 
 case "$1" in


### PR DESCRIPTION
I'm running as a non-root user that doesn't have access to /var/run. What I have to do so that the user has access to the pid file is to create it beforehand:
```sh
sudo touch /var/run/$appName.pid
sudo chown $userName /var/run/$appName.pid
```
But this results in `Already running` all the time because the script checks only for file existence. My change checks for something in the file too.