### PR TITLE
replace 'Brace Expansion' on 'Standard syntax'

### DIFF
--- a/template
+++ b/template
@@ -49,7 +49,8 @@ case "$1" in
     if is_running; then
         echo -n "Stopping $name.."
         kill `get_pid`
-        for i in {1..10}
+        for i in 1 2 3 4 5 6 7 8 9 10
+        # for i in `seq 10`
         do
             if ! is_running; then
                 break


### PR DESCRIPTION
 'Brace Expansion' normally works in bash. 
https://www.gnu.org/software/bash/manual/bash.html
On some system default shell interpreter could be another from Bash, for example 
(flask) vagrant@vagrant:~/flask$ cat /etc/lsb-release
...
DISTRIB_DESCRIPTION="Ubuntu 14.04.4 LTS"
vagrant@vagrant:~/flask$ ls -l /bin/sh
lrwxrwxrwx 1 root root 4 Feb 19  2014 /bin/sh -> dash

So, it's better to chose some standard syntax.
http://tldp.org/LDP/abs/html/loops1.html
