### PR TITLE
Allow user associated with process to stop it.

### DIFF
--- a/template
+++ b/template
@@ -9,9 +9,9 @@
 # Description:       Enable service provided by daemon.
 ### END INIT INFO
 
-dir="/home/debian"
-cmd="python3 $dir/script"
-user="debian"
+dir=""
+cmd=""
+user=""
 
 name=`basename $0`
 pid_file="/var/run/$name.pid"

--- a/template
+++ b/template
@@ -9,9 +9,9 @@
 # Description:       Enable service provided by daemon.
 ### END INIT INFO
 
-dir=""
-cmd=""
-user=""
+dir="/home/debian"
+cmd="python3 $dir/script"
+user="debian"
 
 name=`basename $0`
 pid_file="/var/run/$name.pid"
@@ -35,10 +35,12 @@ case "$1" in
         cd "$dir"
         if [ -z "$user" ]; then
             sudo $cmd >> "$stdout_log" 2>> "$stderr_log" &
+            echo $! > "$pid_file"
         else
             sudo -u "$user" $cmd >> "$stdout_log" 2>> "$stderr_log" &
+            sleep 1 # process not always started fast enough
+            echo $(pgrep -U "$user" -xf "$cmd") > "$pid_file"
         fi
-        echo $! > "$pid_file"
         if ! is_running; then
             echo "Unable to start, see $stdout_log and $stderr_log"
             exit 1


### PR DESCRIPTION
As explained in #20 the process stored in `/var/run/pid_file` is the PID for the command `sudo -U <user> <cmd>` which causes an error when the user attempts to stop the process since `kill <pid>` is not allowed because the pid is owned by root.

`pgrep -U "$user" -xf "$cmd"` captures the pid for the actual running script which is owned by `$user`, therefore allowing them to successfully stop the service without sudo.