### PR TITLE
Kill process group instead of just process

### DIFF
--- a/template
+++ b/template
@@ -26,6 +26,10 @@ is_running() {
     [ -f "$pid_file" ] && ps -p `get_pid` > /dev/null 2>&1
 }
 
+kill_process() {
+    kill -- -$(ps -o pgid= `get_pid` | grep -o [0-9]*)
+}
+
 case "$1" in
     start)
     if is_running; then
@@ -48,7 +52,7 @@ case "$1" in
     stop)
     if is_running; then
         echo -n "Stopping $name.."
-        kill `get_pid`
+        kill_process
         for i in 1 2 3 4 5 6 7 8 9 10
         # for i in `seq 10`
         do

--- a/template
+++ b/template
@@ -13,7 +13,7 @@ dir=""
 cmd=""
 user=""
 
-name=`basename $0`
+name=`basename $(readlink -f $0)`
 pid_file="/var/run/$name.pid"
 stdout_log="/var/log/$name.log"
 stderr_log="/var/log/$name.err"


### PR DESCRIPTION
This was not working for forks as it was only killing the ancestor.
Updated the template to kill the whole tree

The command for killing a process group is from this [SO answer](https://stackoverflow.com/questions/392022/whats-the-best-way-to-send-a-signal-to-all-members-of-a-process-group/15139734#15139734)